### PR TITLE
Fix GitHub pipeline (worker count, LFS fetching, and minor fixes)

### DIFF
--- a/.github/workflows/github-ci-commit.yml
+++ b/.github/workflows/github-ci-commit.yml
@@ -80,7 +80,6 @@ jobs:
         run: |
           uv run pytest -v test/api_accessible \
             --junitxml=report.xml \
-            -n 5 \
             --cov=src/pydpeet \
             --cov-report=term \
             --cov-report=html:coverage_html \

--- a/.github/workflows/github-ci-commit.yml
+++ b/.github/workflows/github-ci-commit.yml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - name: init
         uses: actions/checkout@v6
+        with:
+          lfs: true
       - name: python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/github-ci-commit.yml
+++ b/.github/workflows/github-ci-commit.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           uv run pytest -v test/api_accessible \
             --junitxml=report.xml \
-            -n 10 \
+            -n 5 \
             --cov=src/pydpeet \
             --cov-report=term \
             --cov-report=html:coverage_html \

--- a/.github/workflows/github-ci-commit.yml
+++ b/.github/workflows/github-ci-commit.yml
@@ -79,6 +79,7 @@ jobs:
       - name: run_tests
         run: |
           uv run pytest -v test/api_accessible \
+            -n auto \
             --junitxml=report.xml \
             --cov=src/pydpeet \
             --cov-report=term \

--- a/.github/workflows/github-ci-merge.yml
+++ b/.github/workflows/github-ci-merge.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs-html
-          path: docs/build/html
+          path: docs/_build/html
           retention-days: 14
   #--------------#
   #--- DEPLOY ---#

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ exclude = [
     "test/",
     "docs/",
     "benchmarks/",
-    "dev_utils/",
+    "_dev_utils/",
     "res/",
     ".*egg-info/",
 ]
@@ -118,6 +118,6 @@ exclude = [
 [tool.coverage.run]
 source = ["src/pydpeet"]
 omit = [
-    "*/dev_utils/*",
+    "*/_dev_utils/*",
     "*/res/*",
 ]

--- a/test/coverage/test_coverage_files.py
+++ b/test/coverage/test_coverage_files.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-from pydpeet.dev_utils.check_test_coverge.check_test_coverage import check_tests_and_generate_missing_test_files
+from pydpeet._dev_utils.check_test_coverge.check_test_coverage import check_tests_and_generate_missing_test_files
 
 
 class TestCoverage:
     def test_full_coverage(self):
         project_root = Path(__file__).resolve().parents[2]
 
-        config_path = project_root / "src/pydpeet/dev_utils/generate_inits/config.json"
+        config_path = project_root / "src/pydpeet/_dev_utils/generate_inits/config.json"
         api_tests = project_root / "test/api_accessible"
         private_tests = project_root / "test/internal"
         src_dir = project_root / "src"
@@ -17,7 +17,7 @@ class TestCoverage:
                 config=config_path,
                 tests_dir=(api_tests, private_tests),
                 src_dir=src_dir,
-                exclude_dirs=["dev_utils", "res"],
+                exclude_dirs=["_dev_utils", "res"],
                 test_prefix="test_",
                 test_ext=".py",
                 case_sensitive=True,


### PR DESCRIPTION
Fixes #7.

This MR fixes the following issues:
- set the '-n' option for pytest to 'auto' to avoid calling it with too many workers
- add 'lfs' flag to checkout for 'test' job to fetch files from LFS (some tests fail otherwise)
- adjust references to '_dev_utils' folder after renaming