### PR TITLE
Add 'workflow_dispatch' to allow manual triggering of pipeline; set number of workers to a fixed value of 2; fix GitHub pages artifact

### DIFF
--- a/.github/workflows/github-ci-commit.yml
+++ b/.github/workflows/github-ci-commit.yml
@@ -1,5 +1,6 @@
 name: CI_Commit
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -81,7 +82,7 @@ jobs:
       - name: run_tests
         run: |
           uv run pytest -v test/api_accessible \
-            -n auto \
+            -n 2 \
             --junitxml=report.xml \
             --cov=src/pydpeet \
             --cov-report=term \

--- a/.github/workflows/github-ci-merge.yml
+++ b/.github/workflows/github-ci-merge.yml
@@ -1,5 +1,6 @@
 name: CI_Merge
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -45,7 +46,7 @@ jobs:
       - name: pages_configure
         uses: actions/configure-pages@v5
       - name: pages_artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           name: docs-html
           path: docs/_build/html


### PR DESCRIPTION
Fixes #9, fixes #10, fixes #11.

This PR does the following:
- allow pipeline to be manually triggered on non-main branches or for testing
- set the number of workers for the 'test' job to a fixed value of 2 to prevent memory overflow when running the job on a local machine
- fix the GitHub Action for uploading the GitHub Pages artifact during the 'build' job to be used in the 'deploy' job