### PR TITLE
Fix GitHub Pages deployment artifact

### DIFF
--- a/.github/workflows/github-ci-merge.yml
+++ b/.github/workflows/github-ci-merge.yml
@@ -64,3 +64,5 @@ jobs:
       - name: pages_deploy
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: docs-html


### PR DESCRIPTION
Fixes #11

This PR adds the `artifact_name` parameter to the deployment step so that it matches the name of the uploaded Pages artifact.

Comment:
I couldn't verify that the deployment completes successfully because it is currently blocked by the repository's GitHub Pages protection rules:

> "The deployment was rejected or didn't satisfy other protection rules.".
