### PR TITLE
Remove version switch for documentation for now; can be reactivated once we've migrated to our own website.

### DIFF
--- a/.github/workflows/github-ci-release-docs.yml
+++ b/.github/workflows/github-ci-release-docs.yml
@@ -1,149 +1,152 @@
-name: CI_Release_Docs
-on:
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Git tag to build (e.g. v0.3.1)"
-        required: true
-        type: string
+#
+#--- Commented until we have migrated from the default GitHub Pages to our own website
+#
+# name: CI_Release_Docs
+# on:
+#   release:
+#     types: [published]
+#   workflow_dispatch:
+#     inputs:
+#       tag:
+#         description: "Git tag to build (e.g. v0.3.1)"
+#         required: true
+#         type: string
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
+# permissions:
+#   contents: write
+#   pages: write
+#   id-token: write
 
-concurrency:
-  group: github-pages
-  cancel-in-progress: true
+# concurrency:
+#   group: github-pages
+#   cancel-in-progress: true
 
-jobs:
-  #-------------#
-  #--- BUILD ---#
-  #-------------#
-  build:
-    runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ inputs.tag || github.event.release.tag_name }}
-    steps:
-      - name: init
-        uses: actions/checkout@v6
-      - name: python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-      - name: uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-      - name: pandoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pandoc
-      - name: tk
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3-tk
-      - name: uv_sync
-        run: uv sync --frozen --group docs
-      - name: docs
-        run: uv run docs/build_docs.py
-      - name: prepare_pages
-        run: |
-          mkdir -p docs/_public/$VERSION
-          cp -r docs/_build/html/* docs/_public/$VERSION/
+# jobs:
+#   #-------------#
+#   #--- BUILD ---#
+#   #-------------#
+#   build:
+#     runs-on: ubuntu-latest
+#     env:
+#       VERSION: ${{ inputs.tag || github.event.release.tag_name }}
+#     steps:
+#       - name: init
+#         uses: actions/checkout@v6
+#       - name: python
+#         uses: actions/setup-python@v6
+#         with:
+#           python-version: "3.13"
+#       - name: uv
+#         uses: astral-sh/setup-uv@v7
+#         with:
+#           enable-cache: true
+#       - name: pandoc
+#         run: |
+#           sudo apt-get update
+#           sudo apt-get install -y pandoc
+#       - name: tk
+#         run: |
+#           sudo apt-get update
+#           sudo apt-get install -y python3-tk
+#       - name: uv_sync
+#         run: uv sync --frozen --group docs
+#       - name: docs
+#         run: uv run docs/build_docs.py
+#       - name: prepare_pages
+#         run: |
+#           mkdir -p docs/_public/$VERSION
+#           cp -r docs/_build/html/* docs/_public/$VERSION/
 
-          if [ "${{ github.event_name }}" = "release" ]; then
-              mkdir -p docs/_public/stable
-              cp -r docs/_build/html/* docs/_public/stable/
-          fi
-      - name: create_switcher
-        run: |
-          mkdir -p docs/_public/_static
+#           if [ "${{ github.event_name }}" = "release" ]; then
+#               mkdir -p docs/_public/stable
+#               cp -r docs/_build/html/* docs/_public/stable/
+#           fi
+#       - name: create_switcher
+#         run: |
+#           mkdir -p docs/_public/_static
 
-          python - <<'PY'
-          import json
-          import subprocess
-          from pathlib import Path
+#           python - <<'PY'
+#           import json
+#           import subprocess
+#           from pathlib import Path
 
-          base_url = "https://eet-tub.github.io/pydpeet"
+#           base_url = "https://eet-tub.github.io/pydpeet"
 
-          tags = subprocess.check_output(
-              ["git", "tag", "--list", "v*", "--sort=-v:refname"],
-              text=True,
-          ).splitlines()
+#           tags = subprocess.check_output(
+#               ["git", "tag", "--list", "v*", "--sort=-v:refname"],
+#               text=True,
+#           ).splitlines()
 
-          switcher = [
-              {
-                  "name": "latest",
-                  "version": "latest",
-                  "url": f"{base_url}/latest/",
-              },
-              {
-                  "name": "stable",
-                  "version": "stable",
-                  "url": f"{base_url}/stable/",
-                  "preferred": True,
-              },
-          ]
+#           switcher = [
+#               {
+#                   "name": "latest",
+#                   "version": "latest",
+#                   "url": f"{base_url}/latest/",
+#               },
+#               {
+#                   "name": "stable",
+#                   "version": "stable",
+#                   "url": f"{base_url}/stable/",
+#                   "preferred": True,
+#               },
+#           ]
 
-          for tag in tags:
-              switcher.append(
-                  {
-                      "name": tag,
-                      "version": tag,
-                      "url": f"{base_url}/{tag}/",
-                  }
-              )
+#           for tag in tags:
+#               switcher.append(
+#                   {
+#                       "name": tag,
+#                       "version": tag,
+#                       "url": f"{base_url}/{tag}/",
+#                   }
+#               )
 
-          Path("docs/_static/switcher.json").write_text(
-              json.dumps(switcher, indent=2) + "\n",
-              encoding="utf-8",
-          )
-          PY
-      - name: pages_configure
-        uses: actions/configure-pages@v5
-      - name: pages_artifact_version
-        uses: actions/upload-pages-artifact@v5
-        with:
-          name: docs-version
-          path: docs/_public/${{ env.VERSION }}/
-          retention-days: 14
-      - name: pages_artifact_stable
-        uses: actions/upload-pages-artifact@v5
-        if: github.event_name == 'release'
-        with:
-          name: docs-stable
-          path: docs/_public/stable/
-          retention-days: 14
-  #----------------------#
-  #--- DEPLOY VERSION ---#
-  #----------------------#
-  deploy_version:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment_version.outputs.page_url }}
-    steps:
-      - name: pages_deploy_version
-        id: deployment_version
-        uses: actions/deploy-pages@v4
-        with:
-          artifact_name: docs-version
-  #---------------------#
-  #--- DEPLOY STABLE ---#
-  #---------------------#
-  deploy_stable:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment_stable.outputs.page_url }}
-    steps:
-      - name: pages_deploy_stable
-        id: deployment_stable
-        uses: actions/deploy-pages@v4
-        with:
-          artifact_name: docs-stable
+#           Path("docs/_static/switcher.json").write_text(
+#               json.dumps(switcher, indent=2) + "\n",
+#               encoding="utf-8",
+#           )
+#           PY
+#       - name: pages_configure
+#         uses: actions/configure-pages@v5
+#       - name: pages_artifact_version
+#         uses: actions/upload-pages-artifact@v5
+#         with:
+#           name: docs-version
+#           path: docs/_public/${{ env.VERSION }}/
+#           retention-days: 14
+#       - name: pages_artifact_stable
+#         uses: actions/upload-pages-artifact@v5
+#         if: github.event_name == 'release'
+#         with:
+#           name: docs-stable
+#           path: docs/_public/stable/
+#           retention-days: 14
+#   #----------------------#
+#   #--- DEPLOY VERSION ---#
+#   #----------------------#
+#   deploy_version:
+#     needs: build
+#     runs-on: ubuntu-latest
+#     environment:
+#       name: github-pages
+#       url: ${{ steps.deployment_version.outputs.page_url }}
+#     steps:
+#       - name: pages_deploy_version
+#         id: deployment_version
+#         uses: actions/deploy-pages@v4
+#         with:
+#           artifact_name: docs-version
+#   #---------------------#
+#   #--- DEPLOY STABLE ---#
+#   #---------------------#
+#   deploy_stable:
+#     needs: build
+#     runs-on: ubuntu-latest
+#     environment:
+#       name: github-pages
+#       url: ${{ steps.deployment_stable.outputs.page_url }}
+#     steps:
+#       - name: pages_deploy_stable
+#         id: deployment_stable
+#         uses: actions/deploy-pages@v4
+#         with:
+#           artifact_name: docs-stable

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -108,7 +107,10 @@ html_theme_options = {
     "navbar_center": ["navbar-nav"],  # Show main navigation links in the center
     "navbar_end": [
         "theme-switcher",
-        "version-switcher",  # saved for later when wie have multiple versions
+        #
+        # --- Version switcher deactivated until we have our own website
+        #
+        # "version-switcher",
         "navbar-icon-links",
         "searchbox.html",
     ],
@@ -129,10 +131,13 @@ html_theme_options = {
             "icon": "fa-brands fa-github",
         },
     ],
-    "switcher": {
-        "json_url": "https://eet-tub.github.io/pydpeet/_static/switcher.json",
-        "version_match": os.environ.get("PYDPEET_DOC_VERSION", "stable"),
-    },
+    #
+    # --- Version switcher deactivated until we have our own website
+    #
+    # "switcher": {
+    #     "json_url": "https://eet-tub.github.io/pydpeet/_static/switcher.json",
+    #     "version_match": os.environ.get("VERSION"),
+    # },
 }
 
 # Controls the sidebar components. `sidebar-nav-bs.html` renders the project tree.


### PR DESCRIPTION
Follow-up of PRs #15 and #16.

Since GitHub Pages seems to only support one version at a time, we should delay building multiple versions (and "stable" and "latest" derivations) until we host our own website.