### PR TITLE
Adjust documentation and CI for gh-pages branch deployment

### DIFF
--- a/.github/workflows/github-ci-merge.yml
+++ b/.github/workflows/github-ci-merge.yml
@@ -59,7 +59,6 @@ jobs:
           name: docs-latest
           path: docs/_public/
           retention-days: 14
-
   #--------------#
   #--- DEPLOY ---#
   #--------------#

--- a/.github/workflows/github-ci-merge.yml
+++ b/.github/workflows/github-ci-merge.yml
@@ -72,13 +72,11 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
-
       - name: download_docs
         uses: actions/download-artifact@v4
         with:
           name: docs-latest
           path: docs-latest
-
       - name: update_latest
         run: |
           rm -rf gh-pages/latest
@@ -88,7 +86,6 @@ jobs:
           cp docs-latest/index.html gh-pages/index.html
 
           touch gh-pages/.nojekyll
-
       - name: commit_and_push
         run: |
           cd gh-pages

--- a/.github/workflows/github-ci-merge.yml
+++ b/.github/workflows/github-ci-merge.yml
@@ -6,9 +6,7 @@ on:
       - main
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: github-pages
@@ -55,26 +53,54 @@ jobs:
           <meta http-equiv="refresh" content="0; url=latest/">
           <a href="latest/">Go to latest documentation</a>
           EOF
-      - name: pages_configure
-        uses: actions/configure-pages@v5
-      - name: pages_artifact
-        uses: actions/upload-pages-artifact@v5
+      - name: upload_docs
+        uses: actions/upload-artifact@v4
         with:
           name: docs-latest
-          path: docs/_public/latest/
+          path: docs/_public/
           retention-days: 14
+
   #--------------#
   #--- DEPLOY ---#
   #--------------#
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment_latest.outputs.page_url }}
     steps:
-      - name: pages_deploy_latest
-        id: deployment_latest
-        uses: actions/deploy-pages@v4
+      - name: checkout_gh_pages
+        uses: actions/checkout@v6
         with:
-          artifact_name: docs-latest
+          ref: gh-pages
+          path: gh-pages
+
+      - name: download_docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-latest
+          path: docs-latest
+
+      - name: update_latest
+        run: |
+          rm -rf gh-pages/latest
+          mkdir -p gh-pages/latest
+          cp -r docs-latest/latest/* gh-pages/latest/
+
+          cp docs-latest/index.html gh-pages/index.html
+
+          touch gh-pages/.nojekyll
+
+      - name: commit_and_push
+        run: |
+          cd gh-pages
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add latest index.html .nojekyll
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update latest documentation"
+            git push origin gh-pages
+          fi

--- a/.github/workflows/github-ci-release-docs.yml
+++ b/.github/workflows/github-ci-release-docs.yml
@@ -1,0 +1,175 @@
+name: CI_Release_Docs
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build (e.g. v0.3.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  #-------------#
+  #--- BUILD ---#
+  #-------------#
+  build:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.tag || github.event.release.tag_name }}
+      PYDPEET_DOC_VERSION: ${{ inputs.tag || github.event.release.tag_name }}
+    steps:
+      - name: init
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
+      - name: tk
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-tk
+
+      - name: uv_sync
+        run: uv sync --frozen --group docs
+
+      - name: docs
+        run: uv run docs/build_docs.py
+
+      - name: prepare_pages
+        run: |
+          mkdir -p docs/_public/$VERSION
+          cp -r docs/_build/html/* docs/_public/$VERSION/
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+              mkdir -p docs/_public/stable
+              cp -r docs/_build/html/* docs/_public/stable/
+          fi
+
+      - name: create_switcher
+        run: |
+          mkdir -p docs/_public/_static
+
+          python - <<'PY'
+          import json
+          import subprocess
+          from pathlib import Path
+
+          base_url = "https://eet-tub.github.io/pydpeet"
+
+          tags = subprocess.check_output(
+              ["git", "tag", "--list", "v*", "--sort=-v:refname"],
+              text=True,
+          ).splitlines()
+
+          switcher = [
+              {
+                  "name": "latest",
+                  "version": "latest",
+                  "url": f"{base_url}/latest/",
+              },
+              {
+                  "name": "stable",
+                  "version": "stable",
+                  "url": f"{base_url}/stable/",
+                  "preferred": True,
+              },
+          ]
+
+          for tag in tags:
+              switcher.append(
+                  {
+                      "name": tag,
+                      "version": tag,
+                      "url": f"{base_url}/{tag}/",
+                  }
+              )
+
+          Path("docs/_public/_static/switcher.json").write_text(
+              json.dumps(switcher, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: upload_docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-version
+          path: docs/_public/
+          retention-days: 14
+
+  #--------------#
+  #--- DEPLOY ---#
+  #--------------#
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.tag || github.event.release.tag_name }}
+    steps:
+      - name: checkout_gh_pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: download_docs
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-version
+          path: docs-version
+
+      - name: update_version
+        run: |
+          rm -rf gh-pages/$VERSION
+          mkdir -p gh-pages/$VERSION
+          cp -r docs-version/$VERSION/* gh-pages/$VERSION/
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+              rm -rf gh-pages/stable
+              mkdir -p gh-pages/stable
+              cp -r docs-version/stable/* gh-pages/stable/
+          fi
+
+          mkdir -p gh-pages/_static
+          cp docs-version/_static/switcher.json gh-pages/_static/switcher.json
+
+          touch gh-pages/.nojekyll
+
+      - name: commit_and_push
+        run: |
+          cd gh-pages
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add . 
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update documentation for $VERSION"
+            git push origin gh-pages
+          fi

--- a/.github/workflows/github-ci-release-docs.yml
+++ b/.github/workflows/github-ci-release-docs.yml
@@ -31,33 +31,26 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.event.release.tag_name }}
           fetch-depth: 0
-
       - name: python
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-
       - name: uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-
       - name: pandoc
         run: |
           sudo apt-get update
           sudo apt-get install -y pandoc
-
       - name: tk
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-tk
-
       - name: uv_sync
         run: uv sync --frozen --group docs
-
       - name: docs
         run: uv run docs/build_docs.py
-
       - name: prepare_pages
         run: |
           mkdir -p docs/_public/$VERSION
@@ -67,7 +60,6 @@ jobs:
               mkdir -p docs/_public/stable
               cp -r docs/_build/html/* docs/_public/stable/
           fi
-
       - name: create_switcher
         run: |
           mkdir -p docs/_public/_static
@@ -134,13 +126,11 @@ jobs:
         with:
           ref: gh-pages
           path: gh-pages
-
       - name: download_docs
         uses: actions/download-artifact@v4
         with:
           name: docs-version
           path: docs-version
-
       - name: update_version
         run: |
           rm -rf gh-pages/$VERSION
@@ -157,7 +147,6 @@ jobs:
           cp docs-version/_static/switcher.json gh-pages/_static/switcher.json
 
           touch gh-pages/.nojekyll
-
       - name: commit_and_push
         run: |
           cd gh-pages

--- a/.github/workflows/github-ci-release-docs.yml
+++ b/.github/workflows/github-ci-release-docs.yml
@@ -104,14 +104,12 @@ jobs:
               encoding="utf-8",
           )
           PY
-
       - name: upload_docs
         uses: actions/upload-artifact@v4
         with:
           name: docs-version
           path: docs/_public/
           retention-days: 14
-
   #--------------#
   #--- DEPLOY ---#
   #--------------#

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -107,10 +108,7 @@ html_theme_options = {
     "navbar_center": ["navbar-nav"],  # Show main navigation links in the center
     "navbar_end": [
         "theme-switcher",
-        #
-        # --- Version switcher deactivated until we have our own website
-        #
-        # "version-switcher",
+        "version-switcher",
         "navbar-icon-links",
         "searchbox.html",
     ],
@@ -121,23 +119,15 @@ html_theme_options = {
     },
     "icon_links": [
         {
-            "name": "GitLab",
-            "url": "https://git.tu-berlin.de/eet_public/pydpeet/",
-            "icon": "fa-brands fa-gitlab",
-        },
-        {
             "name": "GitHub",
             "url": "https://github.com/eet-tub/pydpeet",
             "icon": "fa-brands fa-github",
         },
     ],
-    #
-    # --- Version switcher deactivated until we have our own website
-    #
-    # "switcher": {
-    #     "json_url": "https://eet-tub.github.io/pydpeet/_static/switcher.json",
-    #     "version_match": os.environ.get("VERSION"),
-    # },
+    "switcher": {
+        "json_url": "https://eet-tub.github.io/pydpeet/_static/switcher.json",
+        "version_match": os.environ.get("PYDPEET_DOC_VERSION", "latest"),
+    },
 }
 
 # Controls the sidebar components. `sidebar-nav-bs.html` renders the project tree.


### PR DESCRIPTION
Closes #14

Previous attempts:
- #19
- #17
- #16

Instead of deploying the documentation via the GitHub Pages artefact workflow, the documentation is now stored directly in the `gh-pages` branch.

This allows individual documentation versions (e.g. `latest`, `stable`, and tagged releases) to coexist without overwriting each other during deployment.

An example is available temporarily at https://schlanto.github.io/pydpeet/ 