### PR TITLE
docs: fill JOSS readiness metadata files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,14 @@
+# Authors
+
+PyDPEET is developed and maintained by the PyDPEET project team.
+
+The package metadata currently lists the following authors:
+
+- Anton Schlösser
+- Martin Otto
+- Alexander Günter Hinrichsen
+- Jan Kalisch
+- Daniel Schröder
+- Cataldo De Simone
+
+For project enquiries, please contact the maintainers at pydpeet@eet.tu-berlin.de.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to PyDPEET can be documented in this file.
+
+This project can follow the general structure of
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and version numbers
+from the package metadata.
+
+## [Unreleased]
+
+### Added
+
+- Initial changelog file for tracking future user-visible changes.
+
+### Changed
+
+- Nothing yet.
+
+### Fixed
+
+- Nothing yet.
+
+## [0.3.1]
+
+- Current package version listed in `pyproject.toml`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+message: "If you use PyDPEET, please cite it using the metadata from this file."
+title: "PyDPEET: Fast and Easy Battery Data Unification, Processing, and Analysis"
+version: "0.3.1"
+type: software
+license: BSD-3-Clause
+repository-code: "https://github.com/eet-tub/pydpeet"
+url: "https://eet-tub.github.io/pydpeet/"
+abstract: "Python package to read, unify, and convert battery measurement data from arbitrary battery cyclers to Parquet files. This package also provides functions to process, evaluate, and visualise the standardised data."
+authors:
+  - family-names: "Schlösser"
+    given-names: "Anton"
+  - family-names: "Otto"
+    given-names: "Martin"
+  - family-names: "Hinrichsen"
+    given-names: "Alexander Günter"
+  - family-names: "Kalisch"
+    given-names: "Jan"
+  - family-names: "Schröder"
+    given-names: "Daniel"
+  - family-names: "De Simone"
+    given-names: "Cataldo"
+contact:
+  - name: "PyDPEET Team"
+    email: "pydpeet@eet.tu-berlin.de"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to PyDPEET
+
+Thank you for considering a contribution to PyDPEET.
+
+PyDPEET focuses on reproducible battery data conversion, processing,
+evaluation, and visualisation workflows. Small, well-scoped contributions are
+the easiest to review and merge.
+
+## Before you start
+
+- For bugs, please open an issue with a minimal reproducible example when
+  possible.
+- For new features, please open or join an issue first so the maintainers can
+  confirm the scope.
+- For new data conversion support, include the cycler model, software version,
+  export settings, battery type, and measurement description. If sample data is
+  required, coordinate with the maintainers before sharing it.
+
+## Development setup
+
+The recommended local setup uses `uv` from the repository root:
+
+```bash
+uv sync --all-groups
+```
+
+The package is installed in editable mode, so local code changes are available
+without reinstalling the package.
+
+## Checks before submitting
+
+Before opening a pull request, please run the relevant checks locally:
+
+```bash
+uv run pre-commit run --all-files
+uv run pytest
+```
+
+If your change affects documentation, also build the documentation:
+
+```bash
+uv run python docs/build_docs.py
+```
+
+## Pull request expectations
+
+- Keep the pull request focused on one topic.
+- Add tests for new behavior or bug fixes.
+- Update documentation when public behavior changes.
+- Avoid committing generated artifacts unless the maintainers request them.
+- Describe what changed and which checks you ran.
+
+For more detail, see the developer guide in `docs/developer.md`.


### PR DESCRIPTION
Hi,

I noticed that `AUTHORS.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `CITATION.cff` already exist but are still empty while #6 tracks filling those files for the JOSS preparation path.

This PR makes a small documentation-only pass:

- fills `AUTHORS.md` from the existing `pyproject.toml` author metadata
- adds a lightweight `CONTRIBUTING.md` aligned with the developer guide
- adds a minimal `CHANGELOG.md` structure
- adds `CITATION.cff` using the current package metadata

No code behavior is changed.

Checks:

- `git diff --check`
- local file sanity check for the four metadata files

Happy to adjust tone or structure if you prefer a different project convention.
